### PR TITLE
`Ember.Select` `.create`, `.reopen`, `.extend` do not issue deprecation warnings

### DIFF
--- a/tests/unit/select-class-deprecation-is-silenced-test.js
+++ b/tests/unit/select-class-deprecation-is-silenced-test.js
@@ -2,13 +2,13 @@ import { module, test } from 'qunit';
 
 import Ember from 'ember';
 
-module('Ember.View');
+module('Ember.Select');
 
 test('does not issue deprecation on create', function(assert){
   assert.expect(1);
 
   try {
-    Ember.View.create();
+    Ember.Select.create();
   } catch(e) {
     assert.ok(false, `An error was thrown unexpectedly: ${e.message}`);
   }
@@ -20,7 +20,19 @@ test('does not issue deprecation on reopen', function(assert){
   assert.expect(1);
 
   try {
-    Ember.View.reopen();
+    Ember.Select.reopen();
+  } catch(e) {
+    assert.ok(false, `An error was thrown unexpectedly: ${e.message}`);
+  }
+
+  assert.ok(true, 'No deprecation is thrown');
+});
+
+test('does not issue deprecation on extend', function(assert){
+  assert.expect(1);
+
+  try {
+    Ember.Select.extend();
   } catch(e) {
     assert.ok(false, `An error was thrown unexpectedly: ${e.message}`);
   }

--- a/tests/unit/view-helper-deprecation-is-silenced-test.js
+++ b/tests/unit/view-helper-deprecation-is-silenced-test.js
@@ -15,7 +15,7 @@ module('{{view "some-view"}}', {
   }
 });
 
-test('doest not issue deprecation on invocation', function(assert){
+test('does not issue deprecation on invocation', function(assert){
   assert.expect(1);
 
   let registry = new Ember.Registry();


### PR DESCRIPTION
(also fixes type "doest" in some tests)

related PR in ember: https://github.com/emberjs/ember.js/pull/11416

fixes #3
