### PR TITLE
Test that `{{view "select"}}` does not issue deprecation

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -12,5 +12,6 @@ var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 */
 
 var app = new EmberAddon();
+app.import(app.bowerDirectory + '/ember/ember-template-compiler.js');
 
 module.exports = app.toTree();

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ember-cli-app-version": "0.3.3",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.0",
-    "ember-cli-htmlbars": "0.7.6",
+    "ember-cli-htmlbars": "0.7.9",
     "ember-cli-htmlbars-inline-precompile": "^0.1.0",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",

--- a/tests/unit/view-select-deprecation-is-silenced-test.js
+++ b/tests/unit/view-select-deprecation-is-silenced-test.js
@@ -5,7 +5,7 @@ import Ember from 'ember';
 
 let component;
 
-module('{{view "some-view"}}', {
+module('{{view "select"}}', {
   teardown() {
     if (component) {
       Ember.run(function() {
@@ -15,13 +15,13 @@ module('{{view "some-view"}}', {
   }
 });
 
-test('does not issue deprecation on invocation', function(assert) {
+test('does not issue deprecation when appended', function(assert){
   assert.expect(1);
 
   let registry = new Ember.Registry();
-  registry.register('view:some-view', Ember.View.extend());
+  registry.register('view:select', Ember.Select);
   registry.register('component:some-component', Ember.Component.extend({
-    layout: hbs`{{view 'some-view'}}`
+    layout: hbs`{{view 'select'}}`
   }));
   let container = registry.container();
   component = container.lookup('component:some-component');
@@ -36,11 +36,11 @@ test('does not issue deprecation on invocation', function(assert) {
   }
 });
 
-test('does not issue deprecation when compiled', function(assert) {
+test('does not issue deprecation when compiled', function(assert){
   assert.expect(1);
 
   try {
-    Ember.HTMLBars.compile('{{view "foo"}}');
+    Ember.HTMLBars.compile('{{view "select"}}');
     assert.ok(true, 'No deprecation is issued.');
   } catch(e) {
     assert.ok(false, `An error was thrown unexpectedly: ${e.message}`);


### PR DESCRIPTION
- pin ember-cli-htmlbars to 0.7.9 so that the _ENABLE_LEGACY_VIEW_SUPPORT env variable gets seen by the compiler
- import the template-compiler so we can unit-test `Ember.HTMLBars.compile` calls

fixes #4
