### PR TITLE
Ember cli 0.28.0 is released as 1.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ not as a permanent solution.
 
 To remove the compile-time deprecation warnings that may appear in the terminal
 output of `ember serve`, make sure your Ember-CLI app is using `ember-cli-htmlbars`
-version `0.7.9` or later (this will be the default for Ember-CLI version 0.28.0 and later).
+version `0.7.9` or later (this will be the default for Ember-CLI version 1.13.0 and later).
 
 ### App Installation
 


### PR DESCRIPTION
Small description fix in README.md.
